### PR TITLE
[FEAT] Add `get-historical-options` tool.

### DIFF
--- a/src/alpha_vantage_mcp/server.py
+++ b/src/alpha_vantage_mcp/server.py
@@ -89,6 +89,57 @@ async def handle_list_tools() -> list[types.Tool]:
                 },
                 "required": ["symbol"],
             },
+        ),
+        types.Tool(
+            name="get-historical-options",
+            description="Get historical options chain data for a stock with sorting capabilities",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "symbol": {
+                        "type": "string",
+                        "description": "Stock symbol (e.g., AAPL, MSFT)",
+                    },
+                    "date": {
+                        "type": "string",
+                        "description": "Optional: Trading date in YYYY-MM-DD format (defaults to previous trading day, must be after 2008-01-01)",
+                        "pattern": "^20[0-9]{2}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12][0-9]|3[01])$"
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "description": "Optional: Number of contracts to return (default: 10, use -1 for all contracts)",
+                        "default": 10,
+                        "minimum": -1
+                    },
+                    "sort_by": {
+                        "type": "string",
+                        "description": "Optional: Field to sort by",
+                        "enum": [
+                            "strike",
+                            "expiration",
+                            "volume",
+                            "open_interest",
+                            "implied_volatility",
+                            "delta",
+                            "gamma",
+                            "theta",
+                            "vega",
+                            "rho",
+                            "last",
+                            "bid",
+                            "ask"
+                        ],
+                        "default": "strike"
+                    },
+                    "sort_order": {
+                        "type": "string",
+                        "description": "Optional: Sort order",
+                        "enum": ["asc", "desc"],
+                        "default": "asc"
+                    }
+                },
+                "required": ["symbol"],
+            },
         )
     ]
 
@@ -224,7 +275,72 @@ def format_time_series(time_series_data: dict) -> str:
         return "\n".join(formatted_data)
     except Exception as e:
         return f"Error formatting time series data: {str(e)}"
-
+    
+def format_historical_options(options_data: dict, limit: int = 10, sort_by: str = "strike", sort_order: str = "asc") -> str:
+    """Format historical options chain data into a concise string with sorting."""
+    try:
+        if "Error Message" in options_data:
+            return f"Error: {options_data['Error Message']}"
+            
+        options_chain = options_data.get("data", [])
+        
+        if not options_chain:
+            return "No options data available in the response"
+            
+        formatted = [
+            f"Historical Options Data:\n",
+            f"Status: {options_data.get('message', 'N/A')}\n",
+            f"Sorted by: {sort_by} ({sort_order})\n\n"
+        ]
+        
+        # Convert string values to float for numeric sorting
+        def get_sort_key(contract):
+            value = contract.get(sort_by, 0)
+            try:
+                # Remove $ and % signs if present
+                if isinstance(value, str):
+                    value = value.replace('$', '').replace('%', '')
+                return float(value)
+            except (ValueError, TypeError):
+                return value
+        
+        # Sort the options chain
+        sorted_chain = sorted(
+            options_chain,
+            key=get_sort_key,
+            reverse=(sort_order == "desc")
+        )
+        
+        # If limit is -1, show all contracts
+        display_contracts = sorted_chain if limit == -1 else sorted_chain[:limit]
+        
+        for contract in display_contracts:
+            formatted.append(f"Contract Details:\n")
+            formatted.append(f"Contract ID: {contract.get('contractID', 'N/A')}\n")
+            formatted.append(f"Expiration: {contract.get('expiration', 'N/A')}\n")
+            formatted.append(f"Strike: ${contract.get('strike', 'N/A')}\n")
+            formatted.append(f"Type: {contract.get('type', 'N/A')}\n")
+            formatted.append(f"Last: ${contract.get('last', 'N/A')}\n")
+            formatted.append(f"Mark: ${contract.get('mark', 'N/A')}\n")
+            formatted.append(f"Bid: ${contract.get('bid', 'N/A')} (Size: {contract.get('bid_size', 'N/A')})\n")
+            formatted.append(f"Ask: ${contract.get('ask', 'N/A')} (Size: {contract.get('ask_size', 'N/A')})\n")
+            formatted.append(f"Volume: {contract.get('volume', 'N/A')}\n")
+            formatted.append(f"Open Interest: {contract.get('open_interest', 'N/A')}\n")
+            formatted.append(f"IV: {contract.get('implied_volatility', 'N/A')}\n")
+            formatted.append(f"Delta: {contract.get('delta', 'N/A')}\n")
+            formatted.append(f"Gamma: {contract.get('gamma', 'N/A')}\n")
+            formatted.append(f"Theta: {contract.get('theta', 'N/A')}\n")
+            formatted.append(f"Vega: {contract.get('vega', 'N/A')}\n")
+            formatted.append(f"Rho: {contract.get('rho', 'N/A')}\n")
+            formatted.append("---\n")
+            
+        if limit != -1 and len(sorted_chain) > limit:
+            formatted.append(f"\n... and {len(sorted_chain) - limit} more contracts")
+            
+        return "".join(formatted)
+    except Exception as e:
+        return f"Error formatting options data: {str(e)}"
+    
 @server.call_tool()
 async def handle_call_tool(
     name: str, arguments: dict | None
@@ -331,6 +447,44 @@ async def handle_call_tool(
             series_text = f"Time series data for {symbol}:\n\n{formatted_series}"
 
             return [types.TextContent(type="text", text=series_text)]
+        
+    elif name == "get-historical-options":
+        symbol = arguments.get("symbol")
+        date = arguments.get("date")
+        limit = arguments.get("limit", 10)
+        sort_by = arguments.get("sort_by", "strike")
+        sort_order = arguments.get("sort_order", "asc")
+        
+        if not symbol:
+            return [types.TextContent(type="text", text="Missing symbol parameter")]
+
+        symbol = symbol.upper()
+        
+        async with httpx.AsyncClient() as client:
+            params = {
+                "function": "HISTORICAL_OPTIONS",
+                "symbol": symbol
+            }
+            if date:
+                params["date"] = date
+                
+            options_data = await make_alpha_request(
+                client,
+                "HISTORICAL_OPTIONS",
+                symbol,
+                params
+            )
+
+            if isinstance(options_data, str):
+                return [types.TextContent(type="text", text=f"Error: {options_data}")]
+
+            formatted_options = format_historical_options(options_data, limit, sort_by, sort_order)
+            options_text = f"Historical options data for {symbol}"
+            if date:
+                options_text += f" on {date}"
+            options_text += f":\n\n{formatted_options}"
+
+            return [types.TextContent(type="text", text=options_text)]
     else:
         return [types.TextContent(type="text", text=f"Unknown tool: {name}")]
 


### PR DESCRIPTION
I wanted to have some extra data for options chain analysis, thought I would just try and add it myself haha.

I also was thinking the main file is getting kinda big now, I would be down to separate out the functionality across a couple files/in different spots. When I tried doing that here I got an issue though, so I thought it would be good in a diff PR